### PR TITLE
requirements dot txt reflects reality

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+setuptools==68.2.2
 asgiref==3.5.2
 backports.zoneinfo==0.2.1
 blessed==1.19.1
@@ -13,7 +14,6 @@ djangorestframework==3.14.0
 djangorestframework-simplejwt==5.2.1
 greenlet==1.1.3
 idna==3.4
-pkg_resources==0.0.0
 Pygments==2.13.0
 PyJWT==2.5.0
 pytz==2022.4


### PR DESCRIPTION
suckin' on a requirements dot txt

`pkg_resources` is deprecated, and it was being Weird without the explicit `setuptools` pin