### PR TITLE
add local dev.env distinct from prod secrets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,9 @@ backend_dev:
 		backend/venv/bin/python3 -m pip install --upgrade pip
 	backend/venv/bin/pip install -r backend/requirements.txt --upgrade	
 
-	test -f secrets.env || \
+	test -f dev.env || \
 		(scripts/secrets decrypt)
-	echo `pwd` && ./scripts/start_backend_dev.sh
+	./scripts/start_backend_dev.sh
 
 archive: backend_archive frontend_archive
 

--- a/README.md
+++ b/README.md
@@ -37,16 +37,23 @@ This should build a docker image, use it to generate the react static, and then 
 
 ## Backend
 
+To run the backend in dev mode, you will need something like the following env vars:
+```sh
+export ROOMBAHT_DEV="true"
+export ROOMBAHT_DJANGO_SECRET_KEY="narrative"
+export ROOMBAHT_EMAIL_HOST_PASSWORD="words"
+export ROOMBAHT_EMAIL_HOST_USER="words"
+export ROOMBAHT_SEND_MAIL="true"
 ```
-$ export ROOMBAHT_DEV="true"
-$ export ROOMBAHT_DJANGO_SECRET_KEY="narrative"
-$ export ROOMBAHT_EMAIL_HOST_PASSWORD="words"
-$ export ROOMBAHT_EMAIL_HOST_USER="words"
-$ export ROOMBAHT_SEND_MAIL="true"
-$ make backend_dev
+You can run `source dev.env` to export the example values stored in that file.
+
+To run the local dev django server, call
+```sh
+make backend_dev
 ```
 
 This should ensure proper depdendencies, initialize and run migrations on sqlite, and start the backend running on port 8080.
+
 
 # Managing a Real Host
 
@@ -64,7 +71,12 @@ There are two scripts to be used for modifying deployed hosts. They each take tw
 
 *Note* Be careful doing this as there are global-vars-as-config.
 
-Run the `populate_reservations.py` script to add new Rooms or Guests.
+Run the `populate_reservations.py` script to add new Rooms and populate with Guests:
+
+```
+source backend/venv/bin/activate
+python populate_reservations.py
+```
 
 # DB Schema
 

--- a/dev.env
+++ b/dev.env
@@ -1,0 +1,7 @@
+export ROOMBAHT_DEV="true"
+export ROOMBAHT_DJANGO_SECRET_KEY="narrative"
+export ROOMBAHT_EMAIL_HOST_PASSWORD="your_password_here"
+export ROOMBAHT_EMAIL_HOST_USER="your_email@here.com"
+export ROOMBAHT_SEND_MAIL="true"
+export DJANGO_SETTINGS_MODULE='backend.settings'
+export RANDOM_ROOMS="TRUE"

--- a/scripts/start_backend_dev.sh
+++ b/scripts/start_backend_dev.sh
@@ -1,15 +1,6 @@
 #!/usr/bin/env bash
 
-source secrets.env
-export ROOMBAHT_DJANGO_SECRET_KEY
-export ROOMBAHT_DB_PASSWORD
-export ROOMBAHT_DB_HOST
-export ROOMBAHT_EMAIL_HOST_USER
-export ROOMBAHT_EMAIL_HOST_PASSWORD
-export ROOMBAHT_SEND_MAIL
-export DJANGO_SETTINGS_MODULE
-export PGPASSWORD="$ROOMBAHT_DB_PASSWORD"
-echo $ROOMBAHT_DJANGO_SECRET_KEY
+source dev.env
 
 source backend/venv/bin/activate
 which python


### PR DESCRIPTION
Instead of entering in all of the target env vars required by django, we can source a file and then run the migrate/runserver script from start_backend_dev.sh