### PR TITLE
ability to disable room swaps by config

### DIFF
--- a/backend/reservations/config.py
+++ b/backend/reservations/config.py
@@ -16,3 +16,4 @@ SEND_ONBOARDING = os.environ.get('ROOMBAHT_SEND_ONBOARDING', 'false').lower() ==
 TEMP_DIR = os.environ.get('ROOMBAHT_TMP', '/tmp')
 
 IGNORE_TRANSACTIONS = os.environ.get('ROOMBAHT_IGNORE_TRANSACTIONS', '').split(',')
+SWAPS_ENABLED = os.environ.get('ROOMBAHT_SWAPS_ENABLED', 'true').lower() == 'true'

--- a/frontend/src/components/dasDataTable.js
+++ b/frontend/src/components/dasDataTable.js
@@ -16,54 +16,58 @@ import ModalImage from "react-modal-image";
 import {ModalRequestSwap} from "./modals.js";
 import { Navigate } from "react-router-dom";
 
-const STORY_HEADERS: TableColumnType<ArrayElementType>[] = [
-    {
-      prop: "number",
-      title: "Number",
-      isSortable: true,
-      isFilterable: true
-    },
-    {
-      prop: "name_take3",
-      title: "Type",
-      isFilterable: true
-    },
-    {
-      prop: "floorplan",
-      title: "FloorPlan",
-      cell: (row) => (
-          <ModalImage
-            small={"layouts/" + row.floorplans[1]}
-            large={"layouts/" + row.floorplans[0]}
-            alt="Babyface_footprint"
-          />
-      )
-    },
-    {
-      prop: "button",
-      cell: (row) => (
-        <ModalRequestSwap row={row}/>
-      )
-    }
-  ];
-
-
 export default class RoomDataTable extends React.Component {
   state = {
     rooms : [],
     jwt: ""
   }
 
+  storyHeaderFactory(swaps_enabled) {
+    let STORY_HEADERS: TableColumnType<ArrayElementType>[] = [
+					{
+					  prop: "number",
+					  title: "Number",
+					  isSortable: true,
+					  isFilterable: true
+					},
+					{
+					  prop: "name_take3",
+					  title: "Type",
+					  isFilterable: true
+					},
+					{
+					  prop: "floorplan",
+					  title: "FloorPlan",
+					  cell: (row) => (
+					    <ModalImage
+					      small={"layouts/" + row.floorplans[1]}
+					      large={"layouts/" + row.floorplans[0]}
+					      alt="Hotel Floor Plan"
+					    />
+					  )
+					},
+					{
+					  prop: "button",
+					  cell: (row) => (
+					    <ModalRequestSwap row={row} swaps_enabled={swaps_enabled} />
+					  )
+					}
+					];
+			       return STORY_HEADERS;
+
+
+
+  };
   componentDidMount() {
     const jwt = JSON.parse(localStorage.getItem('jwt'));
-    console.log("ALL THE ROOMSSS");
     axios.post(process.env.REACT_APP_API_ENDPOINT+"/api/rooms/", {
             jwt: jwt["jwt"]
       })
       .then(res => {
         console.log(res.data);
         const data = res.data
-        this.state.rooms = data
+        this.state.rooms = data.rooms;
+	this.state.swaps_enabled = data.swaps_enabled;
         this.setState({ data  });
       })
       .catch((error) => {
@@ -85,7 +89,7 @@ export default class RoomDataTable extends React.Component {
     return(
       <DatatableWrapper
         body={this.state.rooms}
-        headers={STORY_HEADERS}
+        headers={this.storyHeaderFactory(this.state.swaps_enabled)}
         paginationOptionsProps={{
           initialState: {
             rowsPerPage: 10,

--- a/frontend/src/components/modals.js
+++ b/frontend/src/components/modals.js
@@ -6,13 +6,13 @@ import Modal from 'react-bootstrap/Modal';
 import axios from 'axios';
 import "../styles/modals.css";
 
-export function ModalRequestSwap({row}) {
+export function ModalRequestSwap(props) {
   const [show, setShow] = useState(false);
   const handleClose = () => setShow(false);
   const handleShow = () => setShow(true);
   const [phrase, setPhrase] = useState("");
   const jwt = JSON.parse(localStorage.getItem('jwt'));
-
+  const row = props.row;
   const handleAPICall = (contacts) => {
     if (contacts === null) {
         return;
@@ -49,13 +49,21 @@ export function ModalRequestSwap({row}) {
 
   return (
     <>
+      {props.swaps_enabled ?
       <Button disabled={row.available ? false : true}
 	    variant={row.available ? "outline-primary" : "outline-secondary"}
             size="sm"
             onClick={handleShow}>
             SendSwapRequest
       </Button>
-
+       :
+       <Button hidden disabled={row.available ? false : true}
+	    variant={row.available ? "outline-primary" : "outline-secondary"}
+            size="sm"
+            onClick={handleShow}>
+            SendSwapRequest
+      </Button>
+      }
       <Modal show={show} onHide={handleClose}>
         <Modal.Header closeButton>
           <Modal.Title>RoomService Room Trader</Modal.Title>
@@ -76,7 +84,7 @@ export function ModalRequestSwap({row}) {
             </Form.Group>
 
           <Button variant="primary" type="submit">
-            Submit 
+            Submit
           </Button>
           </Form>
 
@@ -90,12 +98,13 @@ export function ModalRequestSwap({row}) {
 }
 
 
-export function ModalEnterCode({row}) {
+export function ModalEnterCode(props) {
   const [show, setShow] = useState(false);
   const handleClose = () => setShow(false);
   const handleShow = () => setShow(true);
   const [phrase, setPhrase] = useState("");
   const jwt = JSON.parse(localStorage.getItem('jwt'));
+  const row = props.row;
 
   const handleAPICall = (code) => {
     axios.post(process.env.REACT_APP_API_ENDPOINT+'/api/swap_it_up/', {
@@ -132,9 +141,15 @@ export function ModalEnterCode({row}) {
 
   return (
     <>
+      {props.swaps_enabled ?
       <Button size="sm" variant="outline-primary" onClick={handleShow}>
           EnterSwapCode
       </Button>
+       :
+      <Button hidden size="sm" variant="outline-primary" onClick={handleShow}>
+          EnterSwapCode
+      </Button>
+      }
 
       <Modal show={show} onHide={handleClose}>
         <Modal.Header closeButton>
@@ -152,7 +167,7 @@ export function ModalEnterCode({row}) {
             </Form.Group>
 
           <Button variant="primary" type="submit">
-            Submit 
+            Submit
           </Button>
           </Form>
 
@@ -165,16 +180,16 @@ export function ModalEnterCode({row}) {
   );
 }
 
-export function ModalCreateCode({row}) {
+export function ModalCreateCode(props) {
   const [show, setShow] = useState(false);
   const handleClose = () => setShow(false);
   const handleShow = () => setShow(true);
   const [phrase, setPhrase] = useState("");
 
   const jwt = JSON.parse(localStorage.getItem('jwt'));
-
+  const row = props.row;
   const handleAPICall = () => {
-  
+
     axios.post(process.env.REACT_APP_API_ENDPOINT+'/api/swap_gen/', {
             jwt: jwt['jwt'],
             number: {row},
@@ -201,9 +216,15 @@ export function ModalCreateCode({row}) {
 
   return (
     <>
+      {props.swaps_enabled ?
       <Button size="sm" variant="outline-primary" onClick={handleAPICall}>
           CreateSwapCode
       </Button>
+       :
+      <Button hidden size="sm" variant="outline-primary" onClick={handleAPICall}>
+          CreateSwapCode
+      </Button>
+      }
 
       <Modal show={show} onHide={handleClose}>
 
@@ -221,7 +242,7 @@ export function ModalCreateCode({row}) {
 
         <Modal.Footer>
           <Button variant="primary" onClick={handleClose}>
-            Close 
+            Close
           </Button>
         </Modal.Footer>
 

--- a/frontend/src/components/myRooms.js
+++ b/frontend/src/components/myRooms.js
@@ -17,29 +17,6 @@ import Modal from 'react-bootstrap/Modal';
 import { useState } from 'react';
 
 
-const STORY_HEADERS: TableColumnType<ArrayElementType>[] = [
-    {
-      prop: "number",
-      title: "Number",
-      isSortable: true,
-    },
-    {
-      prop: "type",
-      title: "Type",
-    },
-    {
-      prop: "button",
-      cell: (row) => (
-        <ModalCreateCode row={row.number}/>
-      )
-    },
-    {
-      prop: "button",
-      cell: (row) => (
-        <ModalEnterCode row={row.number}/>
-      )
-    },
-  ];
 
 export default class MyRoomsTable extends React.Component {
   state = {
@@ -47,6 +24,32 @@ export default class MyRoomsTable extends React.Component {
     jwt: ""
   }
 
+  storyHeaderFactory(swaps_enabled) {
+    let STORY_HEADERS: TableColumnType<ArrayElementType>[] = [
+					{
+					  prop: "number",
+					  title: "Number",
+					  isSortable: true,
+					},
+					{
+					  prop: "type",
+					  title: "Type",
+					},
+					{
+					  prop: "button",
+					  cell: (row) => (
+					    <ModalCreateCode row={row.number} swaps_enabled={swaps_enabled}/>
+					  )
+					},
+					{
+					  prop: "button",
+					  cell: (row) => (
+					    <ModalEnterCode row={row.number} swaps_enabled={swaps_enabled}/>
+					  )
+					},
+					];
+					return STORY_HEADERS;
+					};
 
   componentDidMount() {
     const jwt = JSON.parse(localStorage.getItem('jwt'));
@@ -56,7 +59,8 @@ export default class MyRoomsTable extends React.Component {
       .then(res => {
         const data = JSON.parse(res.data)
         console.log(JSON.parse(JSON.stringify(data)));
-        this.state.rooms = data
+        this.state.rooms = data.rooms;
+	this.state.swaps_enabled = data.swaps_enabled;
         this.setState({ data  });
 
       })
@@ -78,7 +82,7 @@ export default class MyRoomsTable extends React.Component {
     return(
       <DatatableWrapper
         body={this.state.rooms}
-        headers={STORY_HEADERS}
+        headers={this.storyHeaderFactory(this.state.swaps_enabled)}
       >
         <Row className="mb-4 p-2">
           <Col


### PR DESCRIPTION
Introduces the `ROOMBAHT_SWAPS_ENABLE` bool (defaults to `true`) which has the following effect

* `swap_request`, `swap_gen`, `swap_it_up` api calls all return 501 if disabled
* swap buttons will not show up if disabled

There is probably a cleaner way to handle the react bits, but this is what I got working...

closes #93 