### PR TITLE
force use of 3.10 on local env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ frontend_dev: frontend_build
 backend_env:
 	test -d backend/venv || \
 		( mkdir backend/venv && \
-			virtualenv -p python3.8 backend/venv) && \
+			virtualenv -p python3.10 backend/venv) && \
 		backend/venv/bin/python3 -m pip install --upgrade pip
 	backend/venv/bin/pip install \
 		-r backend/requirements.txt \
@@ -72,6 +72,7 @@ backend_clean_data:
 
 # clean up build artifacts and such
 backend_distclean: backend_clean backend_clean_data
+	rm -rf backend/venv
 
 backend_clean:
 	rm -rf build/roombaht-backend.tgz

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,4 @@
 asgiref==3.5.2
-backports.zoneinfo==0.2.1;python_version<"3.9"
 blessed==1.19.1
 bpython==0.23
 certifi==2022.9.24

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,3 @@
-setuptools==68.2.2
 asgiref==3.5.2
 backports.zoneinfo==0.2.1;python_version<"3.9"
 blessed==1.19.1
@@ -23,8 +22,8 @@ six==1.16.0
 sqlparse==0.4.3
 urllib3==1.26.12
 wcwidth==0.2.5
-uwsgi==2.0.22
-psycopg2==2.9.9
+uwsgi==2.0.27
+psycopg2==2.9.10
 fuzzywuzzy==0.18.0
 pydantic==2.4.2
 python-Levenshtein==0.23.0
@@ -32,4 +31,6 @@ jinja2==3.1.4
 boto3==1.35.34
 aws-secretsmanager-caching==1.1.3
 ec2_metadata==2.13.0
+wheel==0.37.1
+setuptools==68.2.2
 ipython


### PR DESCRIPTION
We should also consider bumping the version of python used, and forcing use of that version (via deadsnakes ppa) on "deployed" hosts.