### PR TITLE
allow overriding ami id. spin down dev env.

### DIFF
--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -6,13 +6,13 @@ resource "aws_route53_zone" "roombaht" {
   }
 }
 
-resource "aws_route53_record" "dev" {
-  zone_id = aws_route53_zone.roombaht.id
-  name = "dev.${var.domain}"
-  type = "A"
-  ttl = "300"
-  records = [module.dev.public_ip]
-}
+#resource "aws_route53_record" "dev" {
+#  zone_id = aws_route53_zone.roombaht.id
+#  name = "dev.${var.domain}"
+#  type = "A"
+#  ttl = "300"
+#  records = [module.dev.public_ip]
+#}
 
 resource "aws_route53_record" "prod" {
   zone_id = aws_route53_zone.roombaht.id

--- a/terraform/host.tf
+++ b/terraform/host.tf
@@ -1,20 +1,20 @@
-module "dev" {
-  source = "./host"
-  environment = "dev"
-  subnet_id = aws_subnet.public.id
-  security_group_id = aws_security_group.roombaht.id
-  ami_id = data.aws_ami.jammy.id
-  iam_profile = aws_iam_instance_profile.roombaht.name
-  kms_key_id = aws_kms_key.roombaht.arn
-  availability_zone = var.availability_zone
-}
+# module "dev" {
+#  source = "./host"
+#  environment = "dev"
+#  subnet_id = aws_subnet.public.id
+#  security_group_id = aws_security_group.roombaht.id
+#  ami_id = data.aws_ami.jammy.id
+#  iam_profile = aws_iam_instance_profile.roombaht.name
+#  kms_key_id = aws_kms_key.roombaht.arn
+#  availability_zone = var.availability_zone
+#}
 
 module "prod" {
   source = "./host"
   environment = "prod"
   subnet_id = aws_subnet.public.id
   security_group_id = aws_security_group.roombaht.id
-  ami_id = data.aws_ami.jammy.id
+  ami_id = try(var.ami_id, data.aws_ami.jammy.id)
   iam_profile = aws_iam_instance_profile.roombaht.name
   kms_key_id = aws_kms_key.roombaht.arn
   availability_zone = var.availability_zone

--- a/terraform/meta.tf
+++ b/terraform/meta.tf
@@ -28,8 +28,10 @@ variable "domain" {
   default = "rooms.take3presents.com"
 }
 
-output "dev_ip" {
-  value = module.dev.public_ip
+variable "ami_id" {
+  type = string
+  description = "Override latest Jammy AMI"
+  default = "ami-0b8c6b923777519db"
 }
 
 output "nameservers" {


### PR DESCRIPTION
Keeping the ami id pinned until we actually bring down prod. Spinning down dev tho.